### PR TITLE
Make config directory if not exists when saving config

### DIFF
--- a/trv/config.go
+++ b/trv/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
@@ -57,7 +58,11 @@ func (c *Config) addSource(s Source) {
 func (c Config) saveConfig() {
 	home, _ := os.UserHomeDir()
 	file, _ := json.MarshalIndent(c, "", " ")
-	_ = ioutil.WriteFile(fmt.Sprintf("%s/.trv/config.json", home), file, 0644)
+	dir := filepath.Join(home, ".trv")
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		_ = os.Mkdir(dir, 0755)
+	}
+	_ = ioutil.WriteFile(filepath.Join(dir, "config.json"), file, 0644)
 }
 
 func (s Source) NewClient() (*github.Client, context.Context, error) {


### PR DESCRIPTION
Fixed an issue where config won't be created if `$HOME/.trv` directory does not exist, which most likely happens for the first time use for all users.

Also, replaced Sprintf() path creation with filepath.Join() for compatibility.